### PR TITLE
attempt to use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     description: 'URL/URI to use for further details.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub complains that Node 12 is deprecated. Let's see if this syntax works to choose Node 16, the new default.
 
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: Sibz/github-status-action, Sibz/github-status-action

Compare with https://github.com/actions/typescript-action/blob/main/action.yml
